### PR TITLE
feat: add global assemblyscript types aliases to the runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ Node.js >= 12 and [webpack 4 or webpack 5](https://github.com/webpack/webpack)
 
 ```sh
 # with npm
-npm install --save-dev as-loader assemblyscript
+npm install as-loader
+npm install --save-dev assemblyscript
 
 # with yarn
-yarn add --dev as-loader assemblyscript
+yarn add as-loader
+yarn add --dev assemblyscript
 ```
 
 The minimal `webpack.config.js`:

--- a/src/runtime/bind.ts
+++ b/src/runtime/bind.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types";
 import { context } from "./context";
 import { AsBindReturnTypes } from "./types/ref-types";
+import "./types/std";
 
 async function instantiate<
   TModule,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -9,6 +9,7 @@ import type {
   AsLoaderModule,
 } from "./types";
 import { context } from "./context";
+import "./types/std";
 
 async function instantiate<TModule>(
   module: TModule | string,

--- a/src/runtime/types/std.ts
+++ b/src/runtime/types/std.ts
@@ -1,0 +1,17 @@
+// Types
+declare type bool = boolean;
+declare type i8 = number;
+declare type i16 = number;
+declare type i32 = number;
+declare type isize = number;
+declare type u8 = number;
+declare type u16 = number;
+declare type u32 = number;
+declare type usize = number;
+declare type f32 = number;
+declare type f64 = number;
+
+/** Special type evaluating the indexed access index type. */
+declare type indexof<T extends unknown[]> = keyof T;
+/** Special type evaluating the indexed access value type. */
+declare type valueof<T extends unknown[]> = T[0];


### PR DESCRIPTION
Add global types aliases to make cross-project type-checking working properly
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.0-canary.18.e658a1b.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-loader@0.7.0-canary.18.e658a1b.0
  # or 
  yarn add as-loader@0.7.0-canary.18.e658a1b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
