### PR TITLE
fix: cast constructor arguments to pointers

### DIFF
--- a/src/runtime/types/pointer.ts
+++ b/src/runtime/types/pointer.ts
@@ -37,8 +37,8 @@ export type PointerCastObject<
 export type PointerCastInstance<
   T extends new (...args: any) => any,
   E = NonPointerTypes
-> = T extends new (...args: any) => infer R
-  ? T & {
+> = T extends new (...args: infer A) => infer R
+  ? (new (...args: PointerCastArray<A, E>) => PointerCastObject<R, E>) & {
       wrap(ptr: Pointer<PointerCastObject<R, E>>): PointerCastObject<R, E>;
     }
   : never;


### PR DESCRIPTION
Closes: #19
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.1-canary.20.e9abe5f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-loader@0.7.1-canary.20.e9abe5f.0
  # or 
  yarn add as-loader@0.7.1-canary.20.e9abe5f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
