### PR TITLE
fix: use correct type in extends directive for __newArray

### DIFF
--- a/src/runtime/types/runtime.ts
+++ b/src/runtime/types/runtime.ts
@@ -73,7 +73,7 @@ export interface AsLoaderRuntime {
   /** Allocates a new string in the module's memory and returns a reference (pointer) to it. */
   __newString(str: string): Pointer<string>;
   /** Allocates a new array in the module's memory and returns a reference (pointer) to it. */
-  __newArray<T extends ArrayLike<T>>(id: number, values: T): Pointer<T>;
+  __newArray<T extends ArrayLike<unknown>>(id: number, values: T): Pointer<T>;
 
   /** Allocates an instance of the class represented by the specified id. */
   __new<T>(size: number, id: TypeId<T>): Pointer<T>;


### PR DESCRIPTION
Closes: #21
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.2-canary.22.ef4db40.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-loader@0.7.2-canary.22.ef4db40.0
  # or 
  yarn add as-loader@0.7.2-canary.22.ef4db40.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
