### PR TITLE
feat: don't export runtime by default for stub runtime

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -47,7 +47,9 @@ function loader(this: any, buffer: Buffer) {
     // default options
     // when user imports wasm with webassembly type, it's not possible to pass env
     runtime: module.type?.startsWith("webassembly") ? "stub" : "incremental",
-    exportRuntime: !module.type?.startsWith("webassembly"),
+    exportRuntime:
+      !module.type?.startsWith("webassembly") &&
+      userAscOptions.exportRuntime !== "stub",
     debug: this.mode === "development",
     optimizeLevel: 3,
     shrinkLevel: 1,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.0-canary.23.b5a3fec.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-loader@0.8.0-canary.23.b5a3fec.0
  # or 
  yarn add as-loader@0.8.0-canary.23.b5a3fec.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
