### PR TITLE
feat: use external loaders for fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,24 @@ module.exports = {
       {
         test: /\.ts$/,
         include: path.resolve(__dirname, "src/assembly"),
-        loader: "as-loader",
-        options: {
-          fallback: true
-        }
+        use: [
+          // fallback loader (must be before as-loader)
+          {
+            loader: "ts-loader",
+            options: {
+              transpileOnly: true
+            }   
+          },   
+          // as-loader, apart from building .wasm file,
+          // will forward assembly script files to the fallback loader above
+          // to build a .js file
+          {
+            loader: "as-loader",
+            options: {
+              fallback: true
+           }
+          }
+        ]
       },
       {
         test: /\.ts$/,

--- a/src/loader/webpack.ts
+++ b/src/loader/webpack.ts
@@ -1,3 +1,5 @@
+import * as webpack from "webpack";
+
 interface CompatibleWebpackModule {
   addWarning?(warning: Error): void;
   addError?(error: Error): void;
@@ -29,4 +31,20 @@ function addErrorToModule(module: CompatibleWebpackModule, error: Error) {
   }
 }
 
-export { addWarningToModule, addErrorToModule };
+function markModuleAsCompiledToWasm(module: webpack.Module) {
+  module.buildMeta.asLoaderCompiledToWasm = true;
+}
+
+function isModuleCompiledToWasm(module: webpack.Module): boolean {
+  return Boolean(
+    module.buildMeta.asLoaderCompiledToWasm ||
+      (module.issuer && isModuleCompiledToWasm(module.issuer))
+  );
+}
+
+export {
+  addWarningToModule,
+  addErrorToModule,
+  markModuleAsCompiledToWasm,
+  isModuleCompiledToWasm,
+};

--- a/test/e2e/fixtures/main/src/fallback.ts
+++ b/test/e2e/fixtures/main/src/fallback.ts
@@ -1,10 +1,11 @@
-import * as assembly from "./assembly/correct/simple";
+import * as assembly from "./assembly/correct/complex";
 
 async function loadAndRun() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const module = await (assembly as any).fallback() as typeof assembly;
 
-  console.log(module.run());
+  const colors = module.getPalette(10);
+  console.log(colors.map(color => color.toString()).join(','))
 }
 
 loadAndRun();

--- a/test/e2e/main.spec.ts
+++ b/test/e2e/main.spec.ts
@@ -168,31 +168,52 @@ describe("as-loader", () => {
         );
         await sandbox.patch(
           "webpack.config.js",
-          '          name: "[name].wasm",',
-          ['          name: "[name].wasm",', "          fallback: true,"].join(
-            "\n"
-          )
+          [
+            '        loader: "as-loader",',
+            "        options: {",
+            '          name: "[name].wasm",',
+            "        },",
+          ].join("\n"),
+          [
+            "        use: [",
+            "          {",
+            '            loader: "ts-loader",',
+            "            options: {",
+            "              transpileOnly: true,",
+            "            }",
+            "          },",
+            "          {",
+            '            loader: "as-loader",',
+            "            options: {",
+            '              name: "[name].wasm",',
+            "              fallback: true,",
+            "            },",
+            "          },",
+            "        ],",
+          ].join("\n")
         );
 
         const webpackResults = await sandbox.exec("yarn webpack");
 
-        expect(webpackResults).toContain("simple.js");
-        expect(webpackResults).toContain("simple.wasm");
-        expect(webpackResults).toContain("simple.wasm.map");
+        expect(webpackResults).toContain("complex.js");
+        expect(webpackResults).toContain("complex.wasm");
+        expect(webpackResults).toContain("complex.wasm.map");
         expect(webpackResults).toContain("main.js");
 
-        expect(await sandbox.exists("dist/simple.js")).toEqual(true);
-        expect(await sandbox.exists("dist/simple.wasm")).toEqual(true);
-        expect(await sandbox.exists("dist/simple.js.map")).toEqual(true);
-        expect(await sandbox.exists("dist/simple.wasm.map")).toEqual(true);
+        expect(await sandbox.exists("dist/complex.js")).toEqual(true);
+        expect(await sandbox.exists("dist/complex.wasm")).toEqual(true);
+        expect(await sandbox.exists("dist/complex.js.map")).toEqual(true);
+        expect(await sandbox.exists("dist/complex.wasm.map")).toEqual(true);
 
-        const simpleJsMap = await sandbox.read("dist/simple.js.map", "utf8");
+        const simpleJsMap = await sandbox.read("dist/complex.js.map", "utf8");
         expect(Object.keys(JSON.parse(simpleJsMap))).toEqual(
           expect.arrayContaining(["version", "sources", "names", "mappings"])
         );
 
         const mainResults = await sandbox.exec("node ./dist/main.js");
-        expect(mainResults).toEqual("15\n");
+        expect(mainResults).toEqual(
+          "rgb(100, 50, 20),rgb(105, 51, 19),rgb(110, 52, 18),rgb(115, 53, 17),rgb(120, 54, 16),rgb(125, 55, 15),rgb(130, 56, 14),rgb(135, 57, 13),rgb(140, 58, 12),rgb(145, 59, 11)\n"
+        );
       }
     );
 


### PR DESCRIPTION
The existing AssemblyScript compiler to JavaScript does not work for all cases and produces large files. Given that AssemblyScript is a subset of TypeScript, we can leverage existing TypeScript loaders :)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.0--canary.26.56f3163.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-loader@0.11.0--canary.26.56f3163.0
  # or 
  yarn add as-loader@0.11.0--canary.26.56f3163.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
