### PR TITLE
feat: drop support for webpack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Installation
 
 This loader requires [AssemblyScript ~0.18](https://github.com/AssemblyScript/assemblyscript), 
-Node.js >= 12 and [webpack 4 or webpack 5](https://github.com/webpack/webpack)
+Node.js >= 12 and [webpack 5](https://github.com/webpack/webpack)
 
 ```sh
 # with npm

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "peerDependencies": {
     "assemblyscript": "^0.19.0",
-    "webpack": "^4.0.0 || ^5.0.0"
+    "webpack": "^5.0.0"
   },
   "dependencies": {
     "@assemblyscript/loader": "^0.19.0",

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -8,12 +8,7 @@ import { createCompilerHost } from "./compiler-host";
 import { mapAscOptionsToArgs, Options } from "./options";
 import { AssemblyScriptError } from "./error";
 import * as schema from "./schema.json";
-import {
-  addErrorToModule,
-  addWarningToModule,
-  isModuleCompiledToWasm,
-  markModuleAsCompiledToWasm,
-} from "./webpack";
+import { isModuleCompiledToWasm, markModuleAsCompiledToWasm } from "./webpack";
 
 const SUPPORTED_EXTENSIONS = [".wasm", ".js"];
 
@@ -151,9 +146,9 @@ function loader(this: any, content: string, map?: any, meta?: any) {
             );
 
             if (diagnostic.category === DiagnosticCategory.ERROR) {
-              addErrorToModule(module, error);
+              module.addError(error);
             } else {
-              addWarningToModule(module, error);
+              module.addWarning(error);
             }
           });
           const errorDiagnostics = diagnostics.filter(

--- a/src/loader/webpack.ts
+++ b/src/loader/webpack.ts
@@ -1,36 +1,5 @@
 import * as webpack from "webpack";
 
-interface CompatibleWebpackModule {
-  addWarning?(warning: Error): void;
-  addError?(error: Error): void;
-  warnings: Error[];
-  errors: Error[];
-}
-
-/**
- * Add warning to module.
- * Supports webpack 4 and webpack 5.
- */
-function addWarningToModule(module: CompatibleWebpackModule, error: Error) {
-  if (typeof module.addWarning === "function") {
-    module.addWarning(error);
-  } else {
-    module.warnings.push(error);
-  }
-}
-
-/**
- * Add error to module.
- * Supports webpack 4 and webpack 5.
- */
-function addErrorToModule(module: CompatibleWebpackModule, error: Error) {
-  if (typeof module.addError === "function") {
-    module.addError(error);
-  } else {
-    module.errors.push(error);
-  }
-}
-
 function markModuleAsCompiledToWasm(module: webpack.Module) {
   module.buildMeta.asLoaderCompiledToWasm = true;
 }
@@ -42,9 +11,4 @@ function isModuleCompiledToWasm(module: webpack.Module): boolean {
   );
 }
 
-export {
-  addWarningToModule,
-  addErrorToModule,
-  markModuleAsCompiledToWasm,
-  isModuleCompiledToWasm,
-};
+export { markModuleAsCompiledToWasm, isModuleCompiledToWasm };

--- a/test/e2e/fixtures/main/package.json
+++ b/test/e2e/fixtures/main/package.json
@@ -13,7 +13,7 @@
     "assemblyscript": "0.19.10",
     "ts-loader": "8.0.17",
     "typescript": "4.2.2",
-    "webpack": "4.46.0",
+    "webpack": "5.24.2",
     "webpack-cli": "4.5.0"
   },
   "engines": {

--- a/test/e2e/main.spec.ts
+++ b/test/e2e/main.spec.ts
@@ -9,9 +9,6 @@ import { instantiate } from "@assemblyscript/loader/umd";
 
 jest.setTimeout(120000);
 
-const WEBPACK_4 = "4.46.0";
-const WEBPACK_5 = "5.24.2";
-
 describe("as-loader", () => {
   let sandbox: Sandbox;
 
@@ -33,85 +30,76 @@ describe("as-loader", () => {
   });
 
   describe("single compilation", () => {
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "works without options with %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+    it("works without options", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        const webpackResults = await sandbox.exec("yarn webpack");
+      const webpackResults = await sandbox.exec("yarn webpack");
 
-        expect(webpackResults).toContain("simple.wasm");
-        expect(webpackResults).toContain("simple.wasm.map");
-        expect(webpackResults).toContain("main.js");
+      expect(webpackResults).toContain("simple.wasm");
+      expect(webpackResults).toContain("simple.wasm.map");
+      expect(webpackResults).toContain("main.js");
 
-        const simpleWasmInstance = await instantiate<
-          typeof import("./fixtures/main/src/assembly/correct/simple")
-        >(await sandbox.read("dist/simple.wasm"));
+      const simpleWasmInstance = await instantiate<
+        typeof import("./fixtures/main/src/assembly/correct/simple")
+      >(await sandbox.read("dist/simple.wasm"));
 
-        expect(simpleWasmInstance.exports.run()).toEqual(15);
+      expect(simpleWasmInstance.exports.run()).toEqual(15);
 
-        const simpleWasmMap = await sandbox.read(
-          "dist/simple.wasm.map",
-          "utf8"
-        );
-        expect(Object.keys(JSON.parse(simpleWasmMap))).toEqual(
-          expect.arrayContaining(["version", "sources", "names", "mappings"])
-        );
+      const simpleWasmMap = await sandbox.read("dist/simple.wasm.map", "utf8");
+      expect(Object.keys(JSON.parse(simpleWasmMap))).toEqual(
+        expect.arrayContaining(["version", "sources", "names", "mappings"])
+      );
 
-        const mainResults = await sandbox.exec("node ./dist/main.js");
-        expect(mainResults).toEqual("15\n");
-      }
-    );
+      const mainResults = await sandbox.exec("node ./dist/main.js");
+      expect(mainResults).toEqual("15\n");
+    });
 
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "reports errors in project with %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+    it("reports errors in project", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        await sandbox.patch(
-          "webpack.config.js",
-          'entry: "./src/correct.ts",',
-          'entry: "./src/broken.ts",'
-        );
+      await sandbox.patch(
+        "webpack.config.js",
+        'entry: "./src/correct.ts",',
+        'entry: "./src/broken.ts",'
+      );
 
-        const results = await sandbox.exec("yarn webpack", { fail: true });
+      const results = await sandbox.exec("yarn webpack", { fail: true });
 
-        expect(results).toContain(
-          [
-            "ERROR in ./src/assembly/broken/simple.ts",
-            "Module build failed (from ./node_modules/as-loader/loader/index.js):",
-            "AssemblyScriptError: Compilation failed - found 3 errors.",
-          ].join("\n")
-        );
-        expect(results).toContain(
-          [
-            "ERROR in ./src/assembly/broken/simple.ts 4:14-15",
-            "Type 'i32' is not assignable to type '~lib/string/String'.",
-          ].join("\n")
-        );
-        expect(results).toContain(
-          [
-            "ERROR in ./src/assembly/broken/shared.ts 2:14-15",
-            "Type 'i32' is not assignable to type '~lib/string/String'.",
-          ].join("\n")
-        );
-        expect(results).toContain(
-          [
-            "ERROR in ./src/assembly/broken/shared.ts 2:10-15",
-            "Type '~lib/string/String' is not assignable to type 'i32'.",
-          ].join("\n")
-        );
-      }
-    );
+      expect(results).toContain(
+        [
+          "ERROR in ./src/assembly/broken/simple.ts",
+          "Module build failed (from ./node_modules/as-loader/loader/index.js):",
+          "AssemblyScriptError: Compilation failed - found 3 errors.",
+        ].join("\n")
+      );
+      expect(results).toContain(
+        [
+          "ERROR in ./src/assembly/broken/simple.ts 4:14-15",
+          "Type 'i32' is not assignable to type '~lib/string/String'.",
+        ].join("\n")
+      );
+      expect(results).toContain(
+        [
+          "ERROR in ./src/assembly/broken/shared.ts 2:14-15",
+          "Type 'i32' is not assignable to type '~lib/string/String'.",
+        ].join("\n")
+      );
+      expect(results).toContain(
+        [
+          "ERROR in ./src/assembly/broken/shared.ts 2:10-15",
+          "Type '~lib/string/String' is not assignable to type 'i32'.",
+        ].join("\n")
+      );
+    });
 
     it.each([
       ["webassembly/sync", "syncWebAssembly"],
       ["webassembly/async", "asyncWebAssembly"],
     ])("loads using %s type", async (type, experiment) => {
       await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-      await sandbox.install("yarn", { webpack: WEBPACK_5 });
+      await sandbox.install("yarn", {});
 
       await sandbox.patch(
         "webpack.config.js",
@@ -155,262 +143,238 @@ describe("as-loader", () => {
       expect(mainResults).toEqual("15\n");
     });
 
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "creates js file for fallback option with %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+    it("creates js file for fallback option", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        await sandbox.patch(
-          "webpack.config.js",
-          '  entry: "./src/correct.ts",',
-          '  entry: "./src/fallback.ts",'
-        );
-        await sandbox.patch(
-          "webpack.config.js",
-          [
-            '        loader: "as-loader",',
-            "        options: {",
-            '          name: "[name].wasm",',
-            "        },",
-          ].join("\n"),
-          [
-            "        use: [",
-            "          {",
-            '            loader: "ts-loader",',
-            "            options: {",
-            "              transpileOnly: true,",
-            "            }",
-            "          },",
-            "          {",
-            '            loader: "as-loader",',
-            "            options: {",
-            '              name: "[name].wasm",',
-            "              fallback: true,",
-            "            },",
-            "          },",
-            "        ],",
-          ].join("\n")
-        );
-
-        const webpackResults = await sandbox.exec("yarn webpack");
-
-        expect(webpackResults).toContain("complex.js");
-        expect(webpackResults).toContain("complex.wasm");
-        expect(webpackResults).toContain("complex.wasm.map");
-        expect(webpackResults).toContain("main.js");
-
-        expect(await sandbox.exists("dist/complex.js")).toEqual(true);
-        expect(await sandbox.exists("dist/complex.wasm")).toEqual(true);
-        expect(await sandbox.exists("dist/complex.js.map")).toEqual(true);
-        expect(await sandbox.exists("dist/complex.wasm.map")).toEqual(true);
-
-        const simpleJsMap = await sandbox.read("dist/complex.js.map", "utf8");
-        expect(Object.keys(JSON.parse(simpleJsMap))).toEqual(
-          expect.arrayContaining(["version", "sources", "names", "mappings"])
-        );
-
-        const mainResults = await sandbox.exec("node ./dist/main.js");
-        expect(mainResults).toEqual(
-          "rgb(100, 50, 20),rgb(105, 51, 19),rgb(110, 52, 18),rgb(115, 53, 17),rgb(120, 54, 16),rgb(125, 55, 15),rgb(130, 56, 14),rgb(135, 57, 13),rgb(140, 58, 12),rgb(145, 59, 11)\n"
-        );
-      }
-    );
-
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "sets correct [contenthash] with %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
-
-        await sandbox.patch(
-          "webpack.config.js",
+      await sandbox.patch(
+        "webpack.config.js",
+        '  entry: "./src/correct.ts",',
+        '  entry: "./src/fallback.ts",'
+      );
+      await sandbox.patch(
+        "webpack.config.js",
+        [
+          '        loader: "as-loader",',
+          "        options: {",
           '          name: "[name].wasm",',
-          '          name: "[name].[contenthash].wasm",'
-        );
+          "        },",
+        ].join("\n"),
+        [
+          "        use: [",
+          "          {",
+          '            loader: "ts-loader",',
+          "            options: {",
+          "              transpileOnly: true,",
+          "            }",
+          "          },",
+          "          {",
+          '            loader: "as-loader",',
+          "            options: {",
+          '              name: "[name].wasm",',
+          "              fallback: true,",
+          "            },",
+          "          },",
+          "        ],",
+        ].join("\n")
+      );
 
-        const webpackResults = await sandbox.exec("yarn webpack");
+      const webpackResults = await sandbox.exec("yarn webpack");
 
-        const simpleWasmFileName = path.join(
-          "dist",
-          (await sandbox.list("dist")).find((dirent) =>
-            dirent.name.endsWith(".wasm")
-          )?.name
-        );
-        const simpleWasmSourceMapFileName = path.join(
-          "dist",
-          (await sandbox.list("dist")).find((dirent) =>
-            dirent.name.endsWith(".wasm.map")
-          )?.name
-        );
+      expect(webpackResults).toContain("complex.js");
+      expect(webpackResults).toContain("complex.wasm");
+      expect(webpackResults).toContain("complex.wasm.map");
+      expect(webpackResults).toContain("main.js");
 
-        expect(simpleWasmFileName).toMatch(/simple\.[0-9a-f]+\.wasm$/);
-        expect(simpleWasmSourceMapFileName).toMatch(
-          /simple\.[0-9a-f]+\.wasm\.map$/
-        );
+      expect(await sandbox.exists("dist/complex.js")).toEqual(true);
+      expect(await sandbox.exists("dist/complex.wasm")).toEqual(true);
+      expect(await sandbox.exists("dist/complex.js.map")).toEqual(true);
+      expect(await sandbox.exists("dist/complex.wasm.map")).toEqual(true);
 
-        expect(webpackResults).toContain(path.basename(simpleWasmFileName));
-        expect(webpackResults).toContain(
-          path.basename(simpleWasmSourceMapFileName)
-        );
+      const simpleJsMap = await sandbox.read("dist/complex.js.map", "utf8");
+      expect(Object.keys(JSON.parse(simpleJsMap))).toEqual(
+        expect.arrayContaining(["version", "sources", "names", "mappings"])
+      );
 
-        const mainResults = await sandbox.exec("node ./dist/main.js");
-        expect(mainResults).toEqual("15\n");
-      }
-    );
+      const mainResults = await sandbox.exec("node ./dist/main.js");
+      expect(mainResults).toEqual(
+        "rgb(100, 50, 20),rgb(105, 51, 19),rgb(110, 52, 18),rgb(115, 53, 17),rgb(120, 54, 16),rgb(125, 55, 15),rgb(130, 56, 14),rgb(135, 57, 13),rgb(140, 58, 12),rgb(145, 59, 11)\n"
+      );
+    });
 
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "compiles example with context data types for %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+    it("sets correct [contenthash]", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        await sandbox.patch(
-          "webpack.config.js",
-          '  entry: "./src/correct.ts",',
-          '  entry: "./src/complex.ts",'
-        );
+      await sandbox.patch(
+        "webpack.config.js",
+        '          name: "[name].wasm",',
+        '          name: "[name].[contenthash].wasm",'
+      );
 
-        const webpackResults = await sandbox.exec("yarn webpack");
+      const webpackResults = await sandbox.exec("yarn webpack");
 
-        expect(webpackResults).toContain("complex.wasm");
-        expect(webpackResults).toContain("complex.wasm.map");
-        expect(webpackResults).toContain("main.js");
+      const simpleWasmFileName = path.join(
+        "dist",
+        (await sandbox.list("dist")).find((dirent) =>
+          dirent.name.endsWith(".wasm")
+        )?.name
+      );
+      const simpleWasmSourceMapFileName = path.join(
+        "dist",
+        (await sandbox.list("dist")).find((dirent) =>
+          dirent.name.endsWith(".wasm.map")
+        )?.name
+      );
 
-        const mainResults = await sandbox.exec("node ./dist/main.js");
-        expect(mainResults).toEqual(
-          "rgb(100, 50, 20),rgb(105, 51, 19),rgb(110, 52, 18),rgb(115, 53, 17),rgb(120, 54, 16),rgb(125, 55, 15),rgb(130, 56, 14),rgb(135, 57, 13),rgb(140, 58, 12),rgb(145, 59, 11)\n"
-        );
-      }
-    );
+      expect(simpleWasmFileName).toMatch(/simple\.[0-9a-f]+\.wasm$/);
+      expect(simpleWasmSourceMapFileName).toMatch(
+        /simple\.[0-9a-f]+\.wasm\.map$/
+      );
 
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "compiles example with bind for %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+      expect(webpackResults).toContain(path.basename(simpleWasmFileName));
+      expect(webpackResults).toContain(
+        path.basename(simpleWasmSourceMapFileName)
+      );
 
-        await sandbox.patch(
-          "webpack.config.js",
-          '  entry: "./src/correct.ts",',
-          '  entry: "./src/bind.ts",'
-        );
-        await sandbox.patch(
-          "webpack.config.js",
-          '          name: "[name].wasm",',
-          ['          name: "[name].wasm",', "          bind: true,"].join("\n")
-        );
+      const mainResults = await sandbox.exec("node ./dist/main.js");
+      expect(mainResults).toEqual("15\n");
+    });
 
-        const webpackResults = await sandbox.exec("yarn webpack");
+    it("compiles example with context data types", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        expect(webpackResults).toContain("bind.wasm");
-        expect(webpackResults).toContain("bind.wasm.map");
-        expect(webpackResults).toContain("main.js");
+      await sandbox.patch(
+        "webpack.config.js",
+        '  entry: "./src/correct.ts",',
+        '  entry: "./src/complex.ts",'
+      );
 
-        const mainResults = await sandbox.exec("node ./dist/main.js");
-        expect(mainResults).toEqual("Hello world!\n");
-      }
-    );
+      const webpackResults = await sandbox.exec("yarn webpack");
+
+      expect(webpackResults).toContain("complex.wasm");
+      expect(webpackResults).toContain("complex.wasm.map");
+      expect(webpackResults).toContain("main.js");
+
+      const mainResults = await sandbox.exec("node ./dist/main.js");
+      expect(mainResults).toEqual(
+        "rgb(100, 50, 20),rgb(105, 51, 19),rgb(110, 52, 18),rgb(115, 53, 17),rgb(120, 54, 16),rgb(125, 55, 15),rgb(130, 56, 14),rgb(135, 57, 13),rgb(140, 58, 12),rgb(145, 59, 11)\n"
+      );
+    });
+
+    it("compiles example with bind", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
+
+      await sandbox.patch(
+        "webpack.config.js",
+        '  entry: "./src/correct.ts",',
+        '  entry: "./src/bind.ts",'
+      );
+      await sandbox.patch(
+        "webpack.config.js",
+        '          name: "[name].wasm",',
+        ['          name: "[name].wasm",', "          bind: true,"].join("\n")
+      );
+
+      const webpackResults = await sandbox.exec("yarn webpack");
+
+      expect(webpackResults).toContain("bind.wasm");
+      expect(webpackResults).toContain("bind.wasm.map");
+      expect(webpackResults).toContain("main.js");
+
+      const mainResults = await sandbox.exec("node ./dist/main.js");
+      expect(mainResults).toEqual("Hello world!\n");
+    });
   });
 
   describe("watch compilation", () => {
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "re-compiles wasm file on change with %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+    it("re-compiles wasm file on change with", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        const webpack = createProcessDriver(
-          await sandbox.spawn("yarn webpack --watch")
-        );
+      const webpack = createProcessDriver(
+        await sandbox.spawn("yarn webpack --watch")
+      );
 
-        await webpack.waitForStdoutIncludes([
-          "simple.wasm ",
-          "simple.wasm.map ",
-        ]);
+      await webpack.waitForStdoutIncludes(["simple.wasm ", "simple.wasm.map "]);
 
-        expect(await sandbox.exists("dist/simple.wasm")).toBe(true);
-        expect(await sandbox.exists("dist/simple.wasm.map")).toBe(true);
+      expect(await sandbox.exists("dist/simple.wasm")).toBe(true);
+      expect(await sandbox.exists("dist/simple.wasm.map")).toBe(true);
 
-        // update assembly script file
-        await sandbox.patch("src/assembly/correct/shared.ts", "a + b", "a - b");
+      // update assembly script file
+      await sandbox.patch("src/assembly/correct/shared.ts", "a + b", "a - b");
 
-        await webpack.waitForStdoutIncludes([
-          "simple.wasm ",
-          "simple.wasm.map ",
-        ]);
+      await webpack.waitForStdoutIncludes(["simple.wasm ", "simple.wasm.map "]);
 
-        const simpleWasmInstance = await instantiate<
-          typeof import("./fixtures/main/src/assembly/correct/simple")
-        >(await sandbox.read(`dist/simple.wasm`));
+      const simpleWasmInstance = await instantiate<
+        typeof import("./fixtures/main/src/assembly/correct/simple")
+      >(await sandbox.read(`dist/simple.wasm`));
 
-        expect(simpleWasmInstance.exports.run()).toEqual(-5);
-      }
-    );
+      expect(simpleWasmInstance.exports.run()).toEqual(-5);
+    });
 
-    it.each([[{ webpack: WEBPACK_4 }], [{ webpack: WEBPACK_5 }]])(
-      "reports errors on change with %p",
-      async (dependencies) => {
-        await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-        await sandbox.install("yarn", dependencies);
+    it("reports errors on change", async () => {
+      await sandbox.load(path.resolve(__dirname, "fixtures/main"));
+      await sandbox.install("yarn", {});
 
-        const webpack = createProcessDriver(
-          await sandbox.spawn("yarn webpack --watch")
-        );
+      const webpack = createProcessDriver(
+        await sandbox.spawn("yarn webpack --watch")
+      );
 
-        await webpack.waitForStdoutIncludes("simple.wasm ");
+      await webpack.waitForStdoutIncludes("simple.wasm ");
 
-        // update assembly script file
-        await sandbox.patch(
-          "src/assembly/correct/shared.ts",
-          "a: i32",
-          "a: string"
-        );
+      // update assembly script file
+      await sandbox.patch(
+        "src/assembly/correct/shared.ts",
+        "a: i32",
+        "a: string"
+      );
 
-        await webpack.waitForStdoutIncludes([
-          "AssemblyScriptError: Compilation failed - found 3 errors.",
-          [
-            "ERROR in ./src/assembly/correct/simple.ts 4:14-15",
-            "Type 'i32' is not assignable to type '~lib/string/String'.",
-          ].join("\n"),
-          [
-            "ERROR in ./src/assembly/correct/shared.ts 2:14-15",
-            "Type 'i32' is not assignable to type '~lib/string/String'.",
-          ].join("\n"),
-          [
-            "ERROR in ./src/assembly/correct/shared.ts 2:10-15",
-            "Type '~lib/string/String' is not assignable to type 'i32'.",
-          ].join("\n"),
-        ]);
+      await webpack.waitForStdoutIncludes([
+        "AssemblyScriptError: Compilation failed - found 3 errors.",
+        [
+          "ERROR in ./src/assembly/correct/simple.ts 4:14-15",
+          "Type 'i32' is not assignable to type '~lib/string/String'.",
+        ].join("\n"),
+        [
+          "ERROR in ./src/assembly/correct/shared.ts 2:14-15",
+          "Type 'i32' is not assignable to type '~lib/string/String'.",
+        ].join("\n"),
+        [
+          "ERROR in ./src/assembly/correct/shared.ts 2:10-15",
+          "Type '~lib/string/String' is not assignable to type 'i32'.",
+        ].join("\n"),
+      ]);
 
-        await sandbox.patch("src/assembly/correct/shared.ts", "a + b", "a - b");
+      await sandbox.patch("src/assembly/correct/shared.ts", "a + b", "a - b");
 
-        await webpack.waitForStdoutIncludes(
-          "AssemblyScriptError: Compilation failed - found 2 errors."
-        );
+      await webpack.waitForStdoutIncludes(
+        "AssemblyScriptError: Compilation failed - found 2 errors."
+      );
 
-        await sandbox.patch(
-          "src/assembly/correct/shared.ts",
-          "a: string",
-          "a: i32"
-        );
+      await sandbox.patch(
+        "src/assembly/correct/shared.ts",
+        "a: string",
+        "a: i32"
+      );
 
-        await webpack.waitForStdoutIncludes("simple.wasm ");
+      await webpack.waitForStdoutIncludes("simple.wasm ");
 
-        const simpleWasm = await sandbox.read(`dist/simple.wasm`);
-        const simpleWasmInstance = await instantiate<
-          typeof import("./fixtures/main/src/assembly/correct/simple")
-        >(simpleWasm);
+      const simpleWasm = await sandbox.read(`dist/simple.wasm`);
+      const simpleWasmInstance = await instantiate<
+        typeof import("./fixtures/main/src/assembly/correct/simple")
+      >(simpleWasm);
 
-        expect(simpleWasmInstance.exports.run()).toEqual(-5);
-      }
-    );
+      expect(simpleWasmInstance.exports.run()).toEqual(-5);
+    });
   });
 
   describe("options", () => {
     it("passes options to assemblyscript compiler", async () => {
       await sandbox.load(path.resolve(__dirname, "fixtures/main"));
-      await sandbox.install("yarn", { webpack: WEBPACK_5 });
+      await sandbox.install("yarn", {});
 
       await sandbox.patch(
         "webpack.config.js",


### PR DESCRIPTION
Webpack 5 is currently a standard, and AssemblyScript targets modern stack.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.12.0--canary.28.65b8785.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install as-loader@0.12.0--canary.28.65b8785.0
  # or 
  yarn add as-loader@0.12.0--canary.28.65b8785.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
